### PR TITLE
修复滚动缩放isScale参数无效的问题

### DIFF
--- a/src/live2d.js
+++ b/src/live2d.js
@@ -174,22 +174,26 @@ class Live2DVue {
     }
 
     modelScaling(scale) {
-        var isMaxScale = this.viewMatrix.isMaxScale();
-        var isMinScale = this.viewMatrix.isMinScale();
-
-        this.viewMatrix.adjustScale(0, 0, scale);
-
-
-        if (!isMaxScale) {
-            if (this.viewMatrix.isMaxScale()) {
-                this.live2DMgr.maxScaleEvent();
+        if (this.isScale == true){
+            var isMaxScale = this.viewMatrix.isMaxScale();
+            var isMinScale = this.viewMatrix.isMinScale();
+    
+            this.viewMatrix.adjustScale(0, 0, scale);
+    
+    
+            if (!isMaxScale) {
+                if (this.viewMatrix.isMaxScale()) {
+                    this.live2DMgr.maxScaleEvent();
+                }
             }
-        }
-
-        if (!isMinScale) {
-            if (this.viewMatrix.isMinScale()) {
-                this.live2DMgr.minScaleEvent();
+    
+            if (!isMinScale) {
+                if (this.viewMatrix.isMinScale()) {
+                    this.live2DMgr.minScaleEvent();
+                }
             }
+        }else{
+            console.log('滚动缩放已被关闭')
         }
     }
 


### PR DESCRIPTION
modelScaling 下增加isScale的判断 为true的时候才生效